### PR TITLE
feat(domain/listRoadmap): Dominio para Listar Roteiros

### DIFF
--- a/src/domain/models/locationModel.ts
+++ b/src/domain/models/locationModel.ts
@@ -1,0 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/ban-types
+type LocationModel = {};
+
+export default LocationModel;

--- a/src/domain/models/roadmapModel.ts
+++ b/src/domain/models/roadmapModel.ts
@@ -1,0 +1,13 @@
+import LocationModel from './locationModel';
+import UserModel from './userModel';
+
+type RoadmapModel = {
+  title: string;
+  description: string;
+  created: UserModel;
+  locations: Array<LocationModel>;
+  quantitySaved: number;
+  quantityLocation: number;
+};
+
+export default RoadmapModel;

--- a/src/domain/models/userModel.ts
+++ b/src/domain/models/userModel.ts
@@ -1,0 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/ban-types
+type UserModel = {};
+
+export default UserModel;

--- a/src/domain/useCases/addAccount.ts
+++ b/src/domain/useCases/addAccount.ts
@@ -1,4 +1,4 @@
-import { AddAccountModel } from '../models/addAccountModel';
+import AddAccountModel from '../models/addAccountModel';
 
 export default interface AddAccount {
   add(accountModel: AddAccountModel): Promise<string>;

--- a/src/domain/useCases/listRoadmap.ts
+++ b/src/domain/useCases/listRoadmap.ts
@@ -1,0 +1,5 @@
+import RoadmapModel from '../models/roadmapModel';
+
+export default interface ListRoadmap {
+  list(): Promise<Array<RoadmapModel>>;
+}


### PR DESCRIPTION
### What?
Cria dominio para listar roteiros.
### Why?
Para que seja possível obter a lista de roteiros para o usuário.
### How?
Ao solicitar ao domínio a lista de roteiros, é retornado um modelo de roteiro com associações com outros modelos (user, locations).

_Obs: Os models de locations e user contém apenas a estrutura por enquanto, devido a necessidade de utilidade e levantamento de infos._
### Testing?
Não possui testes unitários.
### Screenshots (optional)
0
### Anything Else?
